### PR TITLE
Remove all context references

### DIFF
--- a/threader_test.go
+++ b/threader_test.go
@@ -1,7 +1,6 @@
 package threader_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -10,11 +9,9 @@ import (
 )
 
 func TestThreader(t *testing.T) {
-	ctx := context.Background()
-
 	t.Run("Default Threader", func(t *testing.T) {
 		t.Run("Panic is caught", func(t *testing.T) {
-			threader.Go(ctx, func() {
+			threader.DefaultThreader.Go(func() {
 				panic(99)
 			})
 		})
@@ -22,13 +19,13 @@ func TestThreader(t *testing.T) {
 	t.Run("Custom Threader", func(t *testing.T) {
 		t.Run("Panic", func(t *testing.T) {
 			threaderInstance := threader.New()
-			threaderInstance.Go(ctx, func() {
+			threaderInstance.Go(func() {
 				// Empty 1
 			})
-			threaderInstance.Go(ctx, func() {
+			threaderInstance.Go(func() {
 				// Empty 2
 			})
-			threaderInstance.Go(ctx, func() {
+			threaderInstance.Go(func() {
 				panic(99)
 			})
 			err := threaderInstance.Wait()
@@ -39,13 +36,13 @@ func TestThreader(t *testing.T) {
 		})
 		t.Run("Error", func(t *testing.T) {
 			threaderInstance := threader.New()
-			threaderInstance.GoWithErr(ctx, func() error {
+			threaderInstance.GoWithErr(func() error {
 				return nil
 			})
-			threaderInstance.GoWithErr(ctx, func() error {
+			threaderInstance.GoWithErr(func() error {
 				return nil
 			})
-			threaderInstance.GoWithErr(ctx, func() error {
+			threaderInstance.GoWithErr(func() error {
 				return fmt.Errorf("my error")
 			})
 			err := threaderInstance.Wait()


### PR DESCRIPTION
This removes all context references from any functions; it turns out that we never used them, so they were just misleading.

In addition, this removes the top-level `Go` and `GoWithErr` functions.  If you want to use the default threader, then reference `threader.DefaultThreader`.  This is generally bad practice, but it's at least explicit now.  Previously, it was too easy to mix and match `threader.Go` and `myThreader.Go` calls; they look too similar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined background task execution to enhance clarity and maintainability.
- **Documentation**
	- Improved inline comments for better understanding of the module structure.
- **Tests**
	- Updated test routines to align with the optimized task handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->